### PR TITLE
WIP for selfhealing feature (if worker exits, job should not be lost)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ working:
     * `COMPOSER_RESOLVER_JOBS_TTL` - specifies the TTL for a job in seconds. It will be dropped afterwards. (default `600`)
     * `COMPOSER_RESOLVER_POLLING_FREQUENCY` - specifies the frequency the workers are polling for new jobs in seconds (default `1`, be careful here and adjust when you scale. Having 500 workers that are all polling every second doesn't sound like a good plan!)
     * `COMPOSER_RESOLVER_TERMINATE_AFTER_RUN` - defines whether the worker process is killed after run (default `1` aka `true`)
+    * `COMPOSER_RESOLVER_JOBS_ATPJ` - specifies the "average time per job" needed to complete in seconds. Optional, used for the default setting of `COMPOSER_RESOLVER_JOBS_SECONDS_TO_WAIT_BEFORE_RETRY`. (default `60`)
+    * `COMPOSER_RESOLVER_JOBS_MAX_RETRIES_PER_JOB` - if a job fails (important: failing does not mean resolving is not possible, failing means the process fails e.g. due to memory overflow) the resolver will wait for `COMPOSER_RESOLVER_JOBS_SECONDS_TO_WAIT_BEFORE_RETRY` seconds and then try again for the configured number of times (default `5`)
+    * `COMPOSER_RESOLVER_JOBS_SECONDS_TO_WAIT_BEFORE_RETRY` - see description of `COMPOSER_RESOLVER_JOBS_MAX_RETRIES_PER_JOB` (default `2 * COMPOSER_RESOLVER_JOBS_ATPJ`)
 
 ### Manage / Scale
 

--- a/app.php
+++ b/app.php
@@ -13,13 +13,15 @@ $app->register(new Predis\Silex\ClientServiceProvider(), [
     ],
 ]);
 
-$app['redis.jobs.queueKey']               = $app->env('COMPOSER_RESOLVER_JOBS_QUEUE_KEY', 'jobs_queue');
-$app['redis.jobs.workerPollingFrequency'] = $app->env('COMPOSER_RESOLVER_POLLING_FREQUENCY', 1, 'int');
-$app['redis.jobs.ttl']                    = $app->env('COMPOSER_RESOLVER_JOBS_TTL', 600, 'int');
-$app['redis.jobs.atpj']                   = $app->env('COMPOSER_RESOLVER_JOBS_ATPJ', 60, 'int');
-$app['redis.jobs.maxFactor']              = $app->env('COMPOSER_RESOLVER_JOBS_MAX_FACTOR', 20, 'int');
-$app['redis.jobs.workers']                = $app->env('COMPOSER_RESOLVER_WORKERS', 1, 'int');
-$app['worker.terminate_after_run']        = $app->env('COMPOSER_RESOLVER_TERMINATE_AFTER_RUN', true, 'bool');
+$app['redis.jobs.queueKey']                     = $app->env('COMPOSER_RESOLVER_JOBS_QUEUE_KEY', 'jobs_queue');
+$app['redis.jobs.workerPollingFrequency']       = $app->env('COMPOSER_RESOLVER_POLLING_FREQUENCY', 1, 'int');
+$app['redis.jobs.ttl']                          = $app->env('COMPOSER_RESOLVER_JOBS_TTL', 600, 'int');
+$app['redis.jobs.atpj']                         = $app->env('COMPOSER_RESOLVER_JOBS_ATPJ', 60, 'int');
+$app['redis.jobs.maxFactor']                    = $app->env('COMPOSER_RESOLVER_JOBS_MAX_FACTOR', 20, 'int');
+$app['redis.jobs.maxRetriesPerJob']             = $app->env('COMPOSER_RESOLVER_JOBS_MAX_RETRIES_PER_JOB', 5, 'int');
+$app['redis.jobs.secondsToWaitBeforeRetry']     = $app->env('COMPOSER_RESOLVER_JOBS_SECONDS_TO_WAIT_BEFORE_RETRY', (int) $app['redis.jobs.atpj'] * 2, 'int');
+$app['redis.jobs.workers']                      = $app->env('COMPOSER_RESOLVER_WORKERS', 1, 'int');
+$app['worker.terminate_after_run']              = $app->env('COMPOSER_RESOLVER_TERMINATE_AFTER_RUN', true, 'bool');
 
 // Log everything to stout
 $app->register(new Silex\Provider\MonologServiceProvider(), array(
@@ -32,7 +34,9 @@ $app['composer-resolver'] = new \Toflar\ComposerResolver\Worker\Resolver(
     $app['logger'],
     __DIR__ . '/jobs',
     $app['redis.jobs.queueKey'],
-    $app['redis.jobs.ttl']
+    $app['redis.jobs.ttl'],
+    $app['redis.jobs.maxRetriesPerJob'],
+    $app['redis.jobs.secondsToWaitBeforeRetry']
 );
 
 return $app;


### PR DESCRIPTION
PR to fix https://github.com/Toflar/composer-resolver/issues/1.

@discordier can I ask you to review the concept of this? I have to admit I'll have some troubles adding unit tests for this.

The concept is to put every job onto a backup queue. That queue is being checked by every worker before the real queue is checked. If there is a job on the backup queue (and that will almost always be the case because every job lands there first obviously) it checks if the job has been there for more than n seconds (configurable) and if it is older, also n number of retries (configurable) are checked. It will then be moved to the real queue again so the next worker checks for it again.